### PR TITLE
Temperature conversion function changed  and deprecated TEMP_CELSIUS constant from Home Assistant

### DIFF
--- a/custom_components/humidex/sensor.py
+++ b/custom_components/humidex/sensor.py
@@ -3,7 +3,7 @@ from homeassistant.const import (CONF_NAME, ATTR_ICON)
 from homeassistant.helpers.entity import Entity
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.temperature import convert as convert_temperature
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from homeassistant.const import (
         ATTR_UNIT_OF_MEASUREMENT,
@@ -90,7 +90,7 @@ class HumidexSensor(Entity):
 
             # Calculate kelvin from celcius or fahrenheit
             entity_unit = temperature.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-            temp = convert_temperature(
+            temp = TemperatureConverter.convert(
                 float(temp), entity_unit, TEMP_CELSIUS
             )
 

--- a/custom_components/humidex/sensor.py
+++ b/custom_components/humidex/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 
 from homeassistant.const import (
         ATTR_UNIT_OF_MEASUREMENT,
-        TEMP_CELSIUS,
+        UnitOfTemperature,
 )
 
 import voluptuous as vol
@@ -91,7 +91,7 @@ class HumidexSensor(Entity):
             # Calculate kelvin from celcius or fahrenheit
             entity_unit = temperature.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
             temp = TemperatureConverter.convert(
-                float(temp), entity_unit, TEMP_CELSIUS
+                float(temp), entity_unit, UnitOfTemperature.CELSIUS
             )
 
             # Calculate dewpoint


### PR DESCRIPTION
This PR is to adapt the function to Home assistant changes in its conversion library : from homeassistant.util.temperature import convert as convert_temperature to homeassistant.util.unit_conversion import TemperatureConverter